### PR TITLE
build config file per run + test fail if no smallMolecule created

### DIFF
--- a/diffdock/__init__.py
+++ b/diffdock/__init__.py
@@ -97,6 +97,7 @@ class Plugin(pwchemPlugin):
 
 		cleanCmd = (
 			f"sed -i '/inference_steps: 20/d' {yamlFile} && "
+			f"sed -i '/^actual_steps:/d' {yamlFile} && "
 			f"sed -i '/model_dir: \\.\\/workdir\\/v1.1\\/score_model/d' {yamlFile} && "
 			f"sed -i '/confidence_model_dir: \\.\\/workdir\\/v1.1\\/confidence_model/d' {yamlFile} && "
 			f"sed -i '/samples_per_complex: 10/d' {yamlFile} && "

--- a/diffdock/__init__.py
+++ b/diffdock/__init__.py
@@ -66,8 +66,7 @@ class Plugin(pwchemPlugin):
 															packageVersion=DIFFDOCK_DIC['version'])
 
 		# Installing package
-		installer.getCloneCommand(cls.getDiffDockGithub(), targeName='DIFFDOCK_CLONED')
-		cls.cleanDiffDockYaml(installer)
+		installer.getClo<neCommand(cls.getDiffDockGithub(), targeName='DIFFDOCK_CLONED')
 
 		installer.getCondaEnvCommand(pythonVersion='3.9', requirementsFile=False) \
 			.addCommand(f'{cls.getEnvActivationCommand(DIFFDOCK_DIC)} && '
@@ -85,25 +84,6 @@ class Plugin(pwchemPlugin):
 		                f'scikit-learn==1.1.0 torchmetrics==0.11.0 dllogger@git+https://github.com/NVIDIA/dllogger.git  '
 		                f'biopython PyYAML scipy spyrmsd biopandas', 'ESM_INSTALLED') \
 			.addPackage(env, ['git', 'conda', 'pip'], default=default)
-
-		cls.cleanDiffDockYaml(installer)
-
-	@classmethod
-	def cleanDiffDockYaml(cls, installer):
-		"""
-        Removes hardcoded default parameters from default_inference_args.yaml.
-        """
-		yamlFile = os.path.join(cls.getVar(DIFFDOCK_DIC['home']), 'DiffDock', 'default_inference_args.yaml')
-
-		cleanCmd = (
-			f"sed -i '/inference_steps: 20/d' {yamlFile} && "
-			f"sed -i '/^actual_steps:/d' {yamlFile} && "
-			f"sed -i '/model_dir: \\.\\/workdir\\/v1.1\\/score_model/d' {yamlFile} && "
-			f"sed -i '/confidence_model_dir: \\.\\/workdir\\/v1.1\\/confidence_model/d' {yamlFile} && "
-			f"sed -i '/samples_per_complex: 10/d' {yamlFile} && "
-			f"sed -i '/no_final_step_noise: true/d' {yamlFile}"
-		)
-		return installer.addCommand(cleanCmd, 'YAML_CLEANED')
 
 	# ---------------------------------- Protocol functions-----------------------
 	@classmethod

--- a/diffdock/__init__.py
+++ b/diffdock/__init__.py
@@ -66,7 +66,7 @@ class Plugin(pwchemPlugin):
 															packageVersion=DIFFDOCK_DIC['version'])
 
 		# Installing package
-		installer.getClo<neCommand(cls.getDiffDockGithub(), targeName='DIFFDOCK_CLONED')
+		installer.getCloneCommand(cls.getDiffDockGithub(), targeName='DIFFDOCK_CLONED')
 
 		installer.getCondaEnvCommand(pythonVersion='3.9', requirementsFile=False) \
 			.addCommand(f'{cls.getEnvActivationCommand(DIFFDOCK_DIC)} && '

--- a/diffdock/protocols/protocol_diffdock_docking.py
+++ b/diffdock/protocols/protocol_diffdock_docking.py
@@ -43,6 +43,12 @@ class ProtDiffDockDocking(EMProtocol):
   """Run a prediction using a DiffDock trained model over a proteins and a set of ligands"""
   _label = 'diffdock docking'
 
+  # DiffDock applies its config file over the parsed arguments, so any of these keys present in the
+  # config silently overrides what we pass in the command line. They must be dropped from it
+  CONFIG_SHADOWED_KEYS = ('inference_steps', 'actual_steps', 'samples_per_complex', 'batch_size',
+                          'no_final_step_noise', 'model_dir', 'confidence_model_dir',
+                          'protein_ligand_csv', 'out_dir')
+
   def __init__(self, **kwargs):
     EMProtocol.__init__(self, **kwargs)
 
@@ -101,14 +107,13 @@ class ProtDiffDockDocking(EMProtocol):
 
   def predictStep(self):
     csvFile = self.buildCSVFile()
+    configFile = self.buildConfigFile()
     outDir = os.path.abspath(self._getExtraPath())
 
     program = f'{pwchemPlugin.getEnvActivationCommand(DIFFDOCK_DIC)} && python -m inference '
-    args = f'--protein_ligand_csv {csvFile} --out_dir {outDir} '
+    args = f'--config {configFile} --protein_ligand_csv {csvFile} --out_dir {outDir} '
     args += f'--inference_steps {self.inferSteps.get()} --samples_per_complex {self.nSamples.get()} ' \
             f'--batch_size {self.batchSize.get()} '
-    if not self.finalDenoise.get():
-      args += '--no_final_step_noise '
 
     scoreModelDir = os.path.dirname(self.scoreModel.get()) if self.scoreModel.get() else './workdir/v1.1/score_model'
     confModelDir = os.path.dirname(self.confidenceModel.get()) if self.confidenceModel.get() else './workdir/v1.1/confidence_model'
@@ -211,3 +216,24 @@ class ProtDiffDockDocking(EMProtocol):
       for smi, title in smiDic.items():
         f.write(f'{title},{iASFile},{smi},\n')
     return csvFile
+
+  def getConfigFile(self):
+    return os.path.abspath(self._getExtraPath('inference_args.yaml'))
+
+  def buildConfigFile(self):
+    """ Builds the DiffDock config file from its defaults, dropping the keys we set ourselves.
+    """
+    defConfFile = diffdockPlugin.getPackageDir(os.path.join('DiffDock', 'default_inference_args.yaml'))
+    confLines = []
+    with open(defConfFile) as fIn:
+      for line in fIn:
+        if line.split(':')[0].strip() not in self.CONFIG_SHADOWED_KEYS:
+          confLines.append(line)
+
+    confFile = self.getConfigFile()
+    with open(confFile, 'w') as f:
+      f.writelines(confLines)
+      # DiffDock skips the last (noisiest) denoising step by default
+      f.write(f'actual_steps: {max(1, self.inferSteps.get() - 1)}\n')
+      f.write(f'no_final_step_noise: {str(not self.finalDenoise.get()).lower()}\n')
+    return confFile

--- a/diffdock/protocols/protocol_diffdock_docking.py
+++ b/diffdock/protocols/protocol_diffdock_docking.py
@@ -39,15 +39,15 @@ from pwchem.utils import getBaseName, pdbqt2other, pdbFromASFile
 from .. import Plugin as diffdockPlugin
 from ..constants import DIFFDOCK_DIC
 
+# DiffDock applies its config file over the parsed arguments, so any of these keys present in the
+# config silently overrides what we pass in the command line. They must be dropped from it
+CONFIG_SHADOWED_KEYS = ('inference_steps', 'actual_steps', 'samples_per_complex', 'batch_size',
+                        'no_final_step_noise', 'model_dir', 'confidence_model_dir',
+                        'protein_ligand_csv', 'out_dir')
+
 class ProtDiffDockDocking(EMProtocol):
   """Run a prediction using a DiffDock trained model over a proteins and a set of ligands"""
   _label = 'diffdock docking'
-
-  # DiffDock applies its config file over the parsed arguments, so any of these keys present in the
-  # config silently overrides what we pass in the command line. They must be dropped from it
-  CONFIG_SHADOWED_KEYS = ('inference_steps', 'actual_steps', 'samples_per_complex', 'batch_size',
-                          'no_final_step_noise', 'model_dir', 'confidence_model_dir',
-                          'protein_ligand_csv', 'out_dir')
 
   def __init__(self, **kwargs):
     EMProtocol.__init__(self, **kwargs)
@@ -227,7 +227,7 @@ class ProtDiffDockDocking(EMProtocol):
     confLines = []
     with open(defConfFile) as fIn:
       for line in fIn:
-        if line.split(':')[0].strip() not in self.CONFIG_SHADOWED_KEYS:
+        if line.split(':')[0].strip() not in CONFIG_SHADOWED_KEYS:
           confLines.append(line)
 
     confFile = self.getConfigFile()

--- a/diffdock/tests/test_diffdock.py
+++ b/diffdock/tests/test_diffdock.py
@@ -86,5 +86,8 @@ class TestDiffDock(BaseTest):
     protDiffDock = self._runDiffDock(self.protImportPDB, protSmallFilter)
 
     self._waitOutput(protDiffDock, 'outputSmallMolecules', sleepTime=10)
-    self.assertIsNotNone(getattr(protDiffDock, 'outputSmallMolecules', None))
+    outputSet = getattr(protDiffDock, 'outputSmallMolecules', None)
+    self.assertIsNotNone(outputSet)
+    # The output set is created even if the sampling generated no pose at all
+    self.assertGreater(outputSet.getSize(), 0, 'DiffDock did not generate any docked pose')
 


### PR DESCRIPTION
Changes:

* buildConfigFile() writes a per-run config to extra/inference_args.yaml - DiffDock's defaults minus the keys the protocol params sets itself and actual_steps.
* The test only checked that outputSmallMolecules exists, now it also tests the output is not empty